### PR TITLE
Add Bio Accelerator

### DIFF
--- a/bionic_itemgroups.json
+++ b/bionic_itemgroups.json
@@ -104,7 +104,8 @@
                 [ "bio_dragon_breath", 10 ],
                 [ "bio_vda", 10 ],
                 [ "bio_int_overloader", 10 ],
-                [ "bio_drill_arm", 10 ]
+                [ "bio_drill_arm", 10 ],
+                [ "bio_accelerator", 10 ]
             ]
         }
     },
@@ -183,7 +184,8 @@
                 [ "bio_dragon_breath", 10 ],
                 [ "bio_vda", 10 ],
                 [ "bio_int_overloader", 10 ],
-                [ "bio_drill_arm", 10 ]
+                [ "bio_drill_arm", 10 ],
+                [ "bio_accelerator", 10 ]
             ]
         }
     }

--- a/bionics.json
+++ b/bionics.json
@@ -65,7 +65,6 @@
     "react_cost": "3 J",
     "act_cost": "1 J",
     "time": "1 s",
-    "activated_on_install": true,
     "trigger_cost": "1 J",
     "enchantments": [
       {

--- a/bionics.json
+++ b/bionics.json
@@ -54,5 +54,31 @@
     "time": "1 s",
     "fake_weapon": "bio_drill_arms_weapon",
     "flags": [ "BIONIC_TOGGLED", "BIONIC_WEAPON", "BIONIC_NPC_USABLE" ]
+  },
+  {
+    "id": "bio_accelerator",
+    "type": "bionic",
+    "name": { "str": "Bio Accelerator Unit" },
+    "description": "Your digestive system has been outfitted series of filters and processors, allowing you to acceleate the natural regenerative process and provides boosts of energy, at the cost of needing to consume more food and water.",
+    "occupied_bodyparts": [ [ "torso", 15 ] ],
+    "flags": [ "BIONIC_TOGGLED", "BIONIC_SLEEP_FRIENDLY" ],
+    "react_cost": "3 J",
+    "act_cost": "1 J",
+    "time": "1 s",
+    "activated_on_install": true,
+    "trigger_cost": "1 J",
+    "enchantments": [
+      {
+        "condition": "ACTIVE",
+        "values": [
+          { "value": "HUNGER", "multiply": 0.25 },
+          { "value": "THIRST", "multiply": 0.25 },
+          { "value": "METABOLISM", "multiply": 0.666 },
+          { "value": "CARDIO_MULTIPLIER", "multiply": 0.1 },
+          { "value": "MENDING_MODIFIER", "multiply": 0.333 },
+          { "value": "REGEN_HP", "multiply": 0.333 }
+        ]
+      }
+    ]
   }
 ]

--- a/cbms.json
+++ b/cbms.json
@@ -53,5 +53,17 @@
     "price": "5000 USD",
     "price_postapoc": "100 USD",
     "difficulty": 8
-  }
+  },
+  {
+        "id": "bio_accelerator",
+        "copy-from": "bionic_general_npc_usable",
+        "type": "BIONIC_ITEM",
+        "name": { "str": "Bio accelerator Unit CBM" },
+        "looks_like": "bio_int_enhancer",
+        "description": "A series of filters and processors that is implanted in the user's digestive system, allowing them to acceleate the natural regenerative process and provides boosts of energy, at the cost of needing to consume more food and water.",
+        "price": "8500 USD",
+        "price_postapoc": "50 USD",
+        "weight": "1500 g",
+        "difficulty": 6
+    }
 ]


### PR DESCRIPTION
Adds bionic to the military and general pool,

Gives the user enchantments when the bionic is active: REGEN_HP, MENDING_MODIFIER, CARDIO_MULTIPLIER, METABOLISM, THIRST, and HUNGER

Gives a drawback of needing more food whilst, providing benefits to healing, more action points through metabolism, increases the cardio by 10%, and increases the rate of calorie drain far higher than it makes the user hungry.

Uses bionic power identical to the bio_recycler to run.